### PR TITLE
Update metadata for ch.dragondreams.delauncher

### DIFF
--- a/src/deigde/deigde/data/deigde.metainfo.xml
+++ b/src/deigde/deigde/data/deigde.metainfo.xml
@@ -109,4 +109,9 @@
 			</description>
 		</release>
 	</releases>
+	<keywords>
+		<keyword>delga file runner</keyword>
+		<keyword>game launcher</keyword>
+		<keyword>dragengine game engine</keyword>
+	</keywords>
 </component>

--- a/src/launcher/gui/data/delauncher-gui.metainfo.xml
+++ b/src/launcher/gui/data/delauncher-gui.metainfo.xml
@@ -92,4 +92,9 @@
 		<value key="DragonDreams::DistroMaintained">%{DISTRO_MAINTAINED}</value>
 		<value key="DragonDreams::DistroMaintainedUpdateUrl">%{DISTRO_MAINTAINED_UPDATE_URL}</value>
 	</custom>
+	<keywords>
+		<keyword>delga file runner</keyword>
+		<keyword>game launcher</keyword>
+		<keyword>dragengine game engine</keyword>
+	</keywords>
 </component>


### PR DESCRIPTION
This PR updates the metadata to improve discoverability and user experience for **Dragengine Launcher**.

---

### 🏷️ Keywords

```
- delga file runner
- game launcher
- dragengine game engine
```

---

*Generated by Metadata Bot 🤖*